### PR TITLE
fix: type issues with nolebase related plugins, configured for duplicated names

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -14,6 +14,17 @@ export default {
   enhanceApp({ app }: EnhanceAppContext) {
     app.component('WarnBadge', WarnBadge)
     app.component('StabilityLevel', StabilityLevel)
-    app.use(NolebaseGitChangelogPlugin)
+    app.use(NolebaseGitChangelogPlugin, {
+      mapAuthors: [
+        {
+          name: 'Kevin Deng',
+          mapByNameAliases: [
+            '三咲智子 Kevin Deng',
+            '三咲智子',
+            '三咲智子 (Kevin)',
+          ],
+        },
+      ],
+    })
   },
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,10 +13,10 @@
     "shiki": "^1.5.1"
   },
   "devDependencies": {
-    "@nolebase/vitepress-plugin-enhanced-mark": "^2.1.0",
-    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.1.0",
-    "@nolebase/vitepress-plugin-git-changelog": "^2.1.0",
-    "@nolebase/vitepress-plugin-highlight-targeted-heading": "^2.1.0",
+    "@nolebase/vitepress-plugin-enhanced-mark": "^2.1.1",
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.1.1",
+    "@nolebase/vitepress-plugin-git-changelog": "^2.1.1",
+    "@nolebase/vitepress-plugin-highlight-targeted-heading": "^2.1.1",
     "@vite-pwa/vitepress": "^0.5.0",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "vite-plugin-pwa": "^0.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,17 +118,17 @@ importers:
         version: 1.5.1
     devDependencies:
       '@nolebase/vitepress-plugin-enhanced-mark':
-        specifier: ^2.1.0
-        version: 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))
+        specifier: ^2.1.1
+        version: 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))
       '@nolebase/vitepress-plugin-enhanced-readabilities':
-        specifier: ^2.1.0
-        version: 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+        specifier: ^2.1.1
+        version: 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
       '@nolebase/vitepress-plugin-git-changelog':
-        specifier: ^2.1.0
-        version: 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+        specifier: ^2.1.1
+        version: 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
       '@nolebase/vitepress-plugin-highlight-targeted-heading':
-        specifier: ^2.1.0
-        version: 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))
+        specifier: ^2.1.1
+        version: 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))
       '@vite-pwa/vitepress':
         specifier: ^0.5.0
         version: 0.5.0(vite-plugin-pwa@0.20.0(@types/babel__core@7.20.5)(vite@5.2.11(@types/node@20.12.11)(less@4.2.0)(terser@5.29.1)))
@@ -2450,8 +2450,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nolebase/ui@2.1.0':
-    resolution: {integrity: sha512-2swYyS/Q1zLm2skxoqPuZ9dv9X6uMP5dgZ34DZo4z43L4iKIQYXWXk/yJWsHIfwe8NgvE5KLNF37KpD7dBSJyQ==}
+  '@nolebase/ui@2.1.1':
+    resolution: {integrity: sha512-3U1/pSLWng6ch1U0yAB1/mXEHiJmwEJxvMugN1mQe7B3w+HE9F37K1YLuCgoGh5TtTIWCBKkraMtIxyKmV8XNw==}
     peerDependencies:
       '@rive-app/canvas': ^2.11.1
       asciinema-player: ^3.7.1
@@ -2465,23 +2465,23 @@ packages:
       vitepress:
         optional: true
 
-  '@nolebase/vitepress-plugin-enhanced-mark@2.1.0':
-    resolution: {integrity: sha512-hupsIEXFpLN3xfyyuL6OsmdhE053LZmCIg73nu4BFsQXHsdPKHWuz/ktjRBa2TfBTjZyCNRWXEXg5o8GhGXYCA==}
+  '@nolebase/vitepress-plugin-enhanced-mark@2.1.1':
+    resolution: {integrity: sha512-ZOfSZ+ObNWRpHrCe6W5mQC0E9X9r4gOl4PuhlXDxo2HqyUOutpbMgiEJ0huYcga7d410WOP8w7uqSx49ubR79Q==}
     peerDependencies:
       vitepress: ^1.2.2
 
-  '@nolebase/vitepress-plugin-enhanced-readabilities@2.1.0':
-    resolution: {integrity: sha512-BsT0MAzeMRmSMkvY0sbC/UWbphJGNNIr5ZYh4n6UmG0NYsYEbNk898tXTXmaDdqzMH9Yttv49lY13Y8uM1t7mg==}
+  '@nolebase/vitepress-plugin-enhanced-readabilities@2.1.1':
+    resolution: {integrity: sha512-LYkdKaNDi+duSEbkikgXOqxNx6e9+ZoJ/ItJdRw4hrrdQgWi3eDCxVZKPpldXqFMFgTq7j7gWs0ZxrfEi4uVJA==}
     peerDependencies:
       vitepress: ^1.2.2
 
-  '@nolebase/vitepress-plugin-git-changelog@2.1.0':
-    resolution: {integrity: sha512-PSYcrmaEhJvytsQkDAEvuDYHX5oKD7RHE+Yy8GCMhGBTkqL3BgrjTehUrEDCLl1dm0izAszSQyb49Tvj/vPL+w==}
+  '@nolebase/vitepress-plugin-git-changelog@2.1.1':
+    resolution: {integrity: sha512-qunlrYNUysylwJ+JDmxSFftaXnKilEyujd5uA7QUEpRA/HvHE4Vh3dnukUJGtKD1Xa5i1W+pSPFvUiyIF+//qw==}
     peerDependencies:
       vitepress: ^1.2.2
 
-  '@nolebase/vitepress-plugin-highlight-targeted-heading@2.1.0':
-    resolution: {integrity: sha512-blq/MUGCuah/lj4jNe/cIiD16HBIhiqodukLhf6S5YvilPz9Qotvnqf0BZ73wEDKtpSq1Bhm5FrB+Ach2ychsQ==}
+  '@nolebase/vitepress-plugin-highlight-targeted-heading@2.1.1':
+    resolution: {integrity: sha512-Z5+49Zkqo8szM/YKjMxMiGO92vMm8ugenU6ltd1T22GZ0lRwxKFPWOhXcjbJtHAZ79sRtZAJHXS+THPG63C51Q==}
     peerDependencies:
       vitepress: ^1.2.2
 
@@ -8193,7 +8193,7 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.4)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-simple-access': 7.24.5
 
   '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.5)':
     dependencies:
@@ -9176,7 +9176,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nolebase/ui@2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
+  '@nolebase/ui@2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
     dependencies:
       '@iconify-json/octicon': 1.1.54
       less: 4.2.0
@@ -9184,16 +9184,16 @@ snapshots:
     optionalDependencies:
       vitepress: 1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5)
 
-  '@nolebase/vitepress-plugin-enhanced-mark@2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))':
+  '@nolebase/vitepress-plugin-enhanced-mark@2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))':
     dependencies:
       less: 4.2.0
       vitepress: 1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5)
 
-  '@nolebase/vitepress-plugin-enhanced-readabilities@2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
+  '@nolebase/vitepress-plugin-enhanced-readabilities@2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
     dependencies:
       '@iconify-json/carbon': 1.1.34
       '@iconify-json/icon-park-outline': 1.1.15
-      '@nolebase/ui': 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+      '@nolebase/ui': 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
       less: 4.2.0
       vitepress: 1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5)
     transitivePeerDependencies:
@@ -9201,10 +9201,10 @@ snapshots:
       - asciinema-player
       - vue
 
-  '@nolebase/vitepress-plugin-git-changelog@2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
+  '@nolebase/vitepress-plugin-git-changelog@2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
     dependencies:
       '@iconify-json/octicon': 1.1.54
-      '@nolebase/ui': 2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+      '@nolebase/ui': 2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
       colorette: 2.0.20
       date-fns: 3.6.0
       defu: 6.1.4
@@ -9220,7 +9220,7 @@ snapshots:
       - asciinema-player
       - vue
 
-  '@nolebase/vitepress-plugin-highlight-targeted-heading@2.1.0(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))':
+  '@nolebase/vitepress-plugin-highlight-targeted-heading@2.1.1(vitepress@1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5))':
     dependencies:
       less: 4.2.0
       vitepress: 1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.1)(typescript@5.4.5)


### PR DESCRIPTION
Bump dependencies of Nolebase plugins to fix https://github.com/vue-macros/vue-macros/actions/runs/9340953898/job/25707140082?pr=695 errors.

Fix was done by @LittleSound through https://github.com/nolebase/integrations/pull/230 .

Since @sxzz used multiple names, configured name alias to aggregate them all into one `Kevin Deng`:

![telegram-cloud-photo-size-1-5112090541121711704-y](https://github.com/XiaoMouz/vue-macros/assets/11081491/51687aee-801f-4203-b106-373cfdc5c529)
